### PR TITLE
Implemented the first work example of the portfolio, Flux Architecture.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 www
+src/res/*/
 
 *._*

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/preset-react": "7.28.5",
         "@babel/preset-typescript": "7.28.5",
         "@eslint/js": "9.18.0",
+        "@types/node": "25.9.1",
         "@types/prop-types": "15.7.15",
         "@types/react": "19.2.15",
         "@types/react-dom": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "webpack": "webpack -c ./webpack.config.cjs",
     "tsc": "tsc",
     "copy-statics": "mkdir -p www && cp ./src/index.html ./www/index.html && cp ./src/res/favicon.ico ./www/favicon.ico && cp ./src/res/FluxArchitectureImage.png ./www/FluxArchitectureImage.png && cp ./src/res/ProfileImage.jpg ./www/ProfileImage.jpg",
-    "build": "npm run lint && npm run tsc && npm run copy-statics && npm run webpack"
+    "build": "npm run lint && ./scripts/copyWorkExamplesStatics.sh && npm run tsc && npm run copy-statics && npm run webpack"
   },
   "eslintConfig": {
     "extends": [
@@ -23,6 +23,7 @@
     "@babel/preset-react": "7.28.5",
     "@babel/preset-typescript": "7.28.5",
     "@eslint/js": "9.18.0",
+    "@types/node": "25.9.1",
     "@types/prop-types": "15.7.15",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",

--- a/scripts/copyWorkExamplesStatics.sh
+++ b/scripts/copyWorkExamplesStatics.sh
@@ -1,0 +1,6 @@
+for dir in ./src/workExamples/*/; do
+  mkdir -p "./src/res/workExamples/$(basename "$dir")"
+  for file in $dir*; do 
+    cp "$file" "./src/res/workExamples/$(basename "$dir")/$(basename "${file%.*}").txt";
+  done
+done

--- a/src/interfaces/components/ITabView.ts
+++ b/src/interfaces/components/ITabView.ts
@@ -1,0 +1,11 @@
+
+import {ISlideShowItem} from "./ISlideShow";
+
+export interface ITabViewItem extends ISlideShowItem {
+    title: string;
+    index: number;
+}
+
+export interface ITabViewProps {
+    items: Array<ITabViewItem>;
+}

--- a/src/interfaces/workExamples/IFluxArchitecture.ts
+++ b/src/interfaces/workExamples/IFluxArchitecture.ts
@@ -1,0 +1,4 @@
+
+export interface IFluxArchitectureProps {
+    className?: string;
+}

--- a/src/logic/WorkExampleLogic.ts
+++ b/src/logic/WorkExampleLogic.ts
@@ -1,10 +1,16 @@
 
 export class WorkExampleLogic {
     /**
+     * 
      * @param classNames 
-     * @returns Class Name string with shared screen class names. Use parameter for custom class name.
+     * @param classNameProp 
+     * @returns Class Name string with shared work example class names. Use parameter for custom class name.
      */
-    public static getClassName(classNames: string[] = []): string {
+    public static getClassName(classNames: string[] = [], classNameProp: string | null = null): string {
+        if (classNameProp) {
+            return ['WorkExample', ...classNames, classNameProp].join(' ');
+        }
+
         return ['WorkExample', ...classNames].join(' ');
     }
 }

--- a/src/styles/color-scheme.less
+++ b/src/styles/color-scheme.less
@@ -1,2 +1,3 @@
 @primary-color: #FA5;
 @secondary-color: #222;
+@border-color: silver;

--- a/src/styles/components/TabView.less
+++ b/src/styles/components/TabView.less
@@ -1,0 +1,21 @@
+
+@import '@Styles/color-scheme';
+
+.TabView {
+    .TabViewHeader {        
+        .headerItem {
+            margin: 0px 1px;
+            padding: 3px;
+            padding-bottom: 0;
+            border: 1px solid @border-color;
+            border-bottom: 0px;
+            border-top-left-radius: 5px;
+            border-top-right-radius: 5px;
+            cursor: pointer;
+
+            &.active {
+                border-color: @primary-color;
+            }
+        }
+    }
+}

--- a/src/styles/workExamples/FluxArchitectureWorkExample.less
+++ b/src/styles/workExamples/FluxArchitectureWorkExample.less
@@ -1,0 +1,14 @@
+
+@import "@Styles/color-scheme";
+
+.FluxArchitectureWorkExample {
+    overflow: auto;
+
+    .code {
+        border: 1px solid @border-color;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+        padding: 0px 5px;
+        overflow-x: scroll;
+    }
+}

--- a/src/views/components/TabView.tsx
+++ b/src/views/components/TabView.tsx
@@ -1,0 +1,37 @@
+
+import {useState} from "react";
+
+import "@Styles/components/TabView.less";
+
+import {
+    ITabViewProps,
+    ITabViewItem
+} from "@Interfaces/components/ITabView";
+
+import {SlideShow} from "./SlideShow";
+
+export function TabView(props: ITabViewProps) {
+    let [index, setIndex] = useState(props.items[0].index);
+
+    return <div className='TabView'>
+        <div className='TabViewHeader'>
+            {props.items.map((item: ITabViewItem) => {
+                let className: string = 'headerItem';
+                if (item.index === index) {
+                    className += ' active';
+                }
+                return <span
+                    key={"headerItem-" + item.index}
+                    className={className}
+                    onClick={() => setIndex(item.index)}
+                >
+                    {item.title}
+                </span>;
+            })}
+        </div>
+        <SlideShow
+            index={index}
+            items={props.items}
+        />
+    </div>;
+}

--- a/src/views/screens/HomeScreen.tsx
+++ b/src/views/screens/HomeScreen.tsx
@@ -57,7 +57,7 @@ export function HomeScreen() {
         {
             render: () => {
                 switch (workExampleIndex) {
-                    case WorkExampleIndex.FLUX_ARCHITECURE: return <FluxArchitectureWorkExample />;
+                    case WorkExampleIndex.FLUX_ARCHITECURE: return <FluxArchitectureWorkExample className='slideshow-content' />;
                     default: return null;
                 }
             }

--- a/src/views/workExamples/FluxArchitectureWorkExample.tsx
+++ b/src/views/workExamples/FluxArchitectureWorkExample.tsx
@@ -1,7 +1,196 @@
 
+import '@Styles/workExamples/FluxArchitectureWorkExample.less';
+
+import {IFluxArchitectureProps} from '@Interfaces/workExamples/IFluxArchitecture';
+
 import {WorkExampleLogic} from '@Logic/WorkExampleLogic';
 
-export function FluxArchitectureWorkExample() {
-    return <div className={WorkExampleLogic.getClassName(['FluxArchitecture'])}>
+import {TabView} from '@Views/components/TabView';
+
+import IActionCode from '@WorkExamples/fluxArchitecture/IAction.txt';
+import ActionCode from '@WorkExamples/fluxArchitecture/Action.txt';
+import IActionDataCode from '@WorkExamples/fluxArchitecture/IActionData.txt';
+import ActionDataCode from '@WorkExamples/fluxArchitecture/ActionData.txt';
+import IDispatcherCode from '@WorkExamples/fluxArchitecture/IDispatcher.txt';
+import DispatcherCode from '@WorkExamples/fluxArchitecture/Dispatcher.txt';
+import IStoreCode from '@WorkExamples/fluxArchitecture/IStore.txt';
+import StoreCode from '@WorkExamples/fluxArchitecture/Store.txt';
+import EventScreenCode from '@WorkExamples/fluxArchitecture/EventScreen.txt';
+import EventStoreCode from '@WorkExamples/fluxArchitecture/EventStore.txt';
+import LoadEventsActionCode from '@WorkExamples/fluxArchitecture/LoadEventsAction.txt';
+
+export function FluxArchitectureWorkExample(props: IFluxArchitectureProps) {
+    return <div className={WorkExampleLogic.getClassName(['FluxArchitectureWorkExample'], props.className)}>
+        <p>
+            The Flux Architecture is a design pattern that uses a dispatcher, stores, and actions to handle state management.<br /><br />
+            The view calls on actions.<br />
+            The actions does something and then dispatches, potentially with data.<br />
+            The Dispatcher notifies the stores.<br />
+            The stores check the dispatch event to see if it&apos;s something they care about. If they do care about it, they update their state accordingly and trigger an update event.<br />
+            The view listens to the store on update event and re-renders with the new store data.<br /><br />
+            As a concrete example, imagine you have a page that lists events. The events are stored on a server&apos;s database and are loaded on page load.<br />
+            This series of operations would occur:
+        </p>
+        <ol>
+            <li>Page init, setup store onUpdate listeners.</li>
+            <li>Page load, call LoadEventsAction.</li>
+            <li>LoadEventsAction requests and receives an events array from server.</li>
+            <li>LoadEventsAction creates an ActionData containing an action identifier and the events array. The action data is dispatched.</li>
+            <li>The dispatcher forwards the dispatched ActionData to the stores.</li>
+            <li>The stores check the action identifier to see if it&apos;s data the store cares about. If the store does not care about the data, it will ignore the data.</li>
+            <li>The EventsStore uses the ActionData to update its internal state with the events array.</li>
+            <li>The EventsStore emits an onUpdate event.</li>
+            <li>The page&apos;s onUpdate listeners receives the event and rerenders with the events array.</li>
+        </ol>
+        <TabView
+            items={[
+                {
+                    title: 'Store',
+                    index: 0,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <p>
+                                The Store class is a base class from which concrete stores extend from.<br /><br />
+                                
+                                It registers itself with the Dispatcher so that it can be notified when an Action completes.<br />
+                                All action completes run through the _update function. Concrete stores implement _update to update store data for actions they respond to.<br />
+                                After a store updates its data, it should return true from _update so that the base class Store will emit an update event.<br /><br />
+
+                                The UI will listen for the Store&apos;s update events so that it can respond to changes in the Store&apos;s data.
+                            </p>
+                            <hr />
+                            <label>IStore</label>
+                            <hr />
+                            <pre><code>{IStoreCode}</code></pre>
+                            <hr />
+                            <label>Store</label>
+                            <hr />
+                            <pre><code>{StoreCode}</code></pre>
+                        </div>;
+                    }
+                },
+                {
+                    title: 'Dispatcher',
+                    index: 1,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <p>
+                                The Dispatcher class is a Singleton. It handles communication between Stores and Actions. <br />
+                                Stores register themselves with the Dispatcher via the register API.<br />
+                                When an Action completes, it will call on the Dispatcher&apos;s dispatch API and the Dispatcher will notify all stores registered with it.
+                            </p>
+                            <hr />
+                            <label>IDispatcher</label>
+                            <hr />
+                            <pre><code>{IDispatcherCode}</code></pre>
+                            <hr />
+                            <label>Dispatcher</label>
+                            <hr />
+                            <pre><code>{DispatcherCode}</code></pre>
+                        </div>;
+                    }
+                },
+                {
+                    title: 'Action',
+                    index: 2,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <p>
+                                The Action class is a base class from which concrete actions extend from.<br /><br />
+
+                                Concrete actions do their work inside the _execute API.<br />
+                                UI will execute actions, causing _execute to be ran. After the _execute returns successfully, the base Action class will dispatch the result of _execute.<br />
+                                Before the data is sent to the Dispatcher, it is wrapped in an ActionData model. This just assigns an identifier to the data so that stores can determine where the data is coming from.<br /><br />
+
+                                The checkType API is a typescript predicate. It allows the stores to narrow the type of action data so that everything is fulled typed. An example of this will be shown in EventStore code snippet. 
+                            </p>
+                            <hr />
+                            <label>IAction</label>
+                            <hr />
+                            <pre><code>{IActionCode}</code></pre>
+                            <hr />
+                            <label>Action</label>
+                            <hr />
+                            <pre><code>{ActionCode}</code></pre>
+                        </div>;
+                    }
+                },
+                {
+                    title: 'ActionData',
+                    index: 3,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <label>IActionData</label>
+                            <hr />
+                            <pre><code>{IActionDataCode}</code></pre>
+                            <hr />
+                            <label>ActionData</label>
+                            <hr />
+                            <pre><code>{ActionDataCode}</code></pre>
+                        </div>;
+                    }
+                },
+                {
+                    title: 'EventScreen',
+                    index: 4,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <p>
+                                This is the example EventScreen.<br /><br />
+
+                                It uses the concrete classes, EventStore and LoadEventsAction, to get the data it wants to display.
+                            </p>
+                            <hr />
+                            <label>EventScreen</label>
+                            <hr />
+                            <pre><code>{EventScreenCode}</code></pre>
+                        </div>;
+                    }
+                },
+                {
+                    title: 'LoadEventsAction',
+                    index: 5,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <p>
+                                This is the example LoadEvents Action.<br /><br />
+                                
+                                Normally you&apos;d have some kind of asynchronous API, either loading from a SQLite Database or making some kind network request.<br />
+                                I just used dummy data for this example.
+                            </p>
+                            <hr />
+                            <label>LoadEventsAction</label>
+                            <hr />
+                            <pre><code>{LoadEventsActionCode}</code></pre>
+                        </div>;
+                    }
+                },
+                {
+                    title: 'EventStore',
+                    index: 6,
+                    render: () => {
+                        return <div className="code">
+                            <hr />
+                            <p>
+                                This is the example EventStore.<br /><br />
+
+                                It has internal variables to hold onto data. The data can be accessed via getter APIs, in this example, getEvents.<br />
+                                The _update API uses the LoadEventsAction&apos;s checkType API to narrow the type of data according to LoadEventsAction&apos;s TResponse typing.
+                            </p>
+                            <hr />
+                            <label>EventStore</label>
+                            <hr />
+                            <pre><code>{EventStoreCode}</code></pre>
+                        </div>;
+                    }
+                }
+            ]}
+        />
     </div>;
 }

--- a/src/workExamples/fluxArchitecture/Action.ts
+++ b/src/workExamples/fluxArchitecture/Action.ts
@@ -1,0 +1,34 @@
+import { IActionData } from './IActionData';
+import { IAction } from './IAction';
+
+import { ActionData } from './ActionData';
+import { Dispatcher } from './Dispatcher';
+
+export abstract class Action<TArgs = void, TResponse = void> implements IAction<TArgs, TResponse> {
+    public abstract getTag(): string;
+
+    /**
+    * 
+    * Checks if ActionData was produced by an Action of this type.
+    * If it was, it would be type of ActionData<TResponse> and the type is narrowed down for typescript.
+    * 
+    * @param ad ActionData received from the Dispatcher
+    * @returns TypeScript Predicate
+    */
+    public checkType(ad: IActionData): ad is IActionData<TResponse> {
+        return ad.getTag() === this.getTag();
+    }
+
+    protected _dispatch(data: TResponse) {
+        Dispatcher.getInstance().dispatch(new ActionData(this.getTag(), data));
+    }
+
+    public execute(args: TArgs): Promise<TResponse> {
+        return this._execute(args).then((result) => {
+            this._dispatch(result);
+            return Promise.resolve(result);
+        });
+    }
+
+    protected abstract _execute(args: TArgs): Promise<TResponse>;
+}

--- a/src/workExamples/fluxArchitecture/ActionData.ts
+++ b/src/workExamples/fluxArchitecture/ActionData.ts
@@ -1,0 +1,19 @@
+import { IActionData } from './IActionData';
+
+export class ActionData<TData = unknown> implements IActionData<TData> {
+    private $tag: string;
+    private $data: TData;
+
+    public constructor(tag: string, data: TData) {
+        this.$tag = tag;
+        this.$data = data;
+    }
+
+    public getTag(): string {
+        return this.$tag;
+    }
+
+    public getData(): TData {
+        return this.$data;
+    }
+}

--- a/src/workExamples/fluxArchitecture/Dispatcher.ts
+++ b/src/workExamples/fluxArchitecture/Dispatcher.ts
@@ -1,0 +1,43 @@
+import { IActionData } from './IActionData';
+
+export class Dispatcher {
+    private $callbacks: Record<string, (data: IActionData) => void>;
+
+    private static $instance: Dispatcher;
+
+    private constructor() {
+        this.$callbacks = {};
+    }
+
+    public static getInstance(): Dispatcher {
+        if (!Dispatcher.$instance) {
+            Dispatcher.$instance = new Dispatcher();
+        }
+
+        return Dispatcher.$instance;
+    }
+
+    public dispatch(data: IActionData): void {
+        for (let i in this.$callbacks) {
+            this.$callbacks[i](data);
+        }
+    }
+
+    /**
+        * 
+        * @param id Must not already be registered.
+        * @param callback 
+        * @returns 
+        */
+    public register(id: string, callback: (data: IActionData) => void): string {
+        if (this.$callbacks[id]) {
+            throw new Error('Duplicater register for id: ' + id);
+        }
+        this.$callbacks[id] = callback;
+        return id;
+    }
+
+    public unregister(id: string): void {
+        delete this.$callbacks[id];
+    }
+}

--- a/src/workExamples/fluxArchitecture/EventScreen.tsx
+++ b/src/workExamples/fluxArchitecture/EventScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+    useState,
+    useEffect
+} from 'react';
+
+import { EventStore } from './EventStore';
+import { LoadEventsAction } from './LoadEventsAction';
+
+export function EventsScreen() {
+    let [events, setEvents] = useState(EventStore.getInstance().getEvents());
+
+    useEffect(() => {
+        const onEventsStoreUpdate = () => {
+            setEvents(EventStore.getInstance().getEvents());
+        };
+        EventStore.getInstance().register(onEventsStoreUpdate);    
+        new LoadEventsAction().execute();
+
+        return () => {
+            EventStore.getInstance().unregister(onEventsStoreUpdate);
+        };
+    }, [setEvents]);
+
+    let eventsUI: React.ReactNode[] = [];
+
+    for (let i = 0, length = events.length; i < length; ++i) {
+        eventsUI.push(<li>{events[i]}</li>);
+    }
+    return <ul>{eventsUI}</ul>;
+}

--- a/src/workExamples/fluxArchitecture/EventStore.ts
+++ b/src/workExamples/fluxArchitecture/EventStore.ts
@@ -1,0 +1,38 @@
+import { Store } from './Store';
+import { IActionData } from './IActionData';
+import { LoadEventsAction } from './LoadEventsAction';
+
+export class EventStore extends Store {
+    private $events: string[];
+    private static $instance: EventStore;
+
+    public constructor() {
+        super();
+        this.$events = [];
+    }
+
+    public static getInstance(): EventStore {
+        if (!EventStore.$instance) {
+            EventStore.$instance = new EventStore();
+        }
+        return EventStore.$instance;
+    }
+
+    protected override _getStoreName() {
+        return 'EventStore';
+    }
+
+    protected override _update(data: IActionData): boolean {
+        if (new LoadEventsAction().checkType(data)) {
+            // The checkType predicate narrows down data's typings, so typescript will know the type of data.getData().
+            this.$events = data.getData();
+            return true;
+        }
+
+        return false;
+    }
+
+    public getEvents(): string[] {
+        return this.$events;
+    }
+}

--- a/src/workExamples/fluxArchitecture/IAction.ts
+++ b/src/workExamples/fluxArchitecture/IAction.ts
@@ -1,0 +1,7 @@
+import { IActionData } from './IActionData';
+
+export interface IAction<TKWArgs = void, TResponse = void> {
+    getTag(): string;
+    execute(kwargs: TKWArgs): Promise<TResponse>;
+    checkType(ad: IActionData<unknown>): ad is IActionData<TResponse>;
+}

--- a/src/workExamples/fluxArchitecture/IActionData.ts
+++ b/src/workExamples/fluxArchitecture/IActionData.ts
@@ -1,0 +1,4 @@
+export interface IActionData<TData = unknown> {
+    getTag(): string;
+    getData(): TData;
+}

--- a/src/workExamples/fluxArchitecture/IDispatcher.ts
+++ b/src/workExamples/fluxArchitecture/IDispatcher.ts
@@ -1,0 +1,7 @@
+import { IActionData } from './IActionData';
+
+export interface IDispatcher {
+    dispatch(data: IActionData): void;
+    register(id: string, callback: (data: IActionData) => void): void;
+    unregister(id: string): void;
+}

--- a/src/workExamples/fluxArchitecture/IStore.ts
+++ b/src/workExamples/fluxArchitecture/IStore.ts
@@ -1,0 +1,4 @@
+export interface IStore {
+    register(callback: () => void): void;
+    unregister(callback: () => void): void;
+}

--- a/src/workExamples/fluxArchitecture/LoadEventsAction.ts
+++ b/src/workExamples/fluxArchitecture/LoadEventsAction.ts
@@ -1,0 +1,17 @@
+import { Action } from './Action';
+
+export class LoadEventsAction extends Action<void, string[]> {
+    public getTag(): string {
+        return 'load-events';
+    }
+
+    protected _execute(): Promise<string[]> {
+        // HTTP Request to server to get event list
+        // We're just going to dummy it out.
+        return Promise.resolve([
+            'event 1',
+            'event 2',
+            'event 3'
+        ]);
+    }
+}

--- a/src/workExamples/fluxArchitecture/Store.ts
+++ b/src/workExamples/fluxArchitecture/Store.ts
@@ -1,0 +1,32 @@
+import { EventEmitter } from 'events';
+import { IStore } from './IStore';
+import { IActionData } from './IActionData';
+import { Dispatcher } from './Dispatcher';
+
+export abstract class Store extends EventEmitter implements IStore {
+    public constructor() {
+        super();
+        this.setMaxListeners(100);
+        Dispatcher.getInstance().register(this._getStoreName(), (data: IActionData) => {
+            if (this._update(data)) {
+                this.$onUpdate();
+            }
+        });
+    }
+
+    protected abstract _getStoreName(): string;
+
+    public register(callback: () => void): void {
+        this.on('update', callback);
+    }
+
+    public unregister(callback: () => void): void {
+        this.removeListener('update', callback);
+    }
+
+    private $onUpdate(): void {
+        this.emit('update');
+    }
+
+    protected abstract _update(data: IActionData): boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,12 +12,15 @@
             "@Styles/*": ["./src/styles/*"],
             "@Res/*": ["./src/res/*"],
             "@Logic/*": ["./src/logic/*"],
-            "@Interfaces/*": ["./src/interfaces/*"]
+            "@Interfaces/*": ["./src/interfaces/*"],
+            "@WorkExamples/*": ["./src/res/workExamples/*"],
         },
-        "jsx": "react-jsx"
+        "jsx": "react-jsx",
+        "types": ["node"]
     },
     "include": [
-        "src/**/*"
+        "src/**/*",
+        "txt.d.ts"
     ],
     "exclude": [
         "node_modules"

--- a/txt.d.ts
+++ b/txt.d.ts
@@ -1,0 +1,5 @@
+
+declare module '*.txt' {
+    const content: string;
+    export default content;
+}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -14,7 +14,8 @@ module.exports = {
             '@Styles': path.resolve(__dirname, './src/styles'),
             '@Res': path.resolve(__dirname, './src/res'),
             '@Logic': path.resolve(__dirname, './src/logic'),
-            '@Interfaces': path.resolve(__dirname, './src/interfaces')
+            '@Interfaces': path.resolve(__dirname, './src/interfaces'),
+            '@WorkExamples': path.resolve(__dirname, './src/res/workExamples')
         }
     },
     module: {
@@ -23,7 +24,8 @@ module.exports = {
                 test: [
                     /(views).*\.tsx$/,
                     /(logic).*\.ts$/,
-                    /(interfaces).*\.ts$/
+                    /(interfaces).*\.ts$/,
+                    /(workExamples).*\.(ts|tsx)$/
                 ],
                 use: {
                     loader: 'babel-loader',
@@ -47,6 +49,10 @@ module.exports = {
                     /(logic).*\.ts$/,
                     /(styles).*\.less$/
                 ]
+            },
+            {
+                test: /(res).*\.txt$/,
+                type: 'asset/source',
             }
         ]
     }


### PR DESCRIPTION
 - Added ts and tsx files to workExamples/fluxArchitectures.
 - Built the copyWorkExamplesStatics script, a script that copies the ts and tsx files from workExamples into the res folder. The files are also renamed to .txt files.
 - Built TabView for FluxArchitectureWorkExample view.
 - Updated webpack's config to support importing txt files.